### PR TITLE
Pass htmlPluginData to callback.

### DIFF
--- a/addAssetHtmlPlugin.js
+++ b/addAssetHtmlPlugin.js
@@ -37,7 +37,7 @@ export default class AddAssetHtmlPlugin {
               return htmlPluginData.plugin.addFileToAssets(`${this.filename}.map`, compilation)
             }
           })
-          .then(() => callback())
+          .then(() => callback(null, htmlPluginData))
       })
     })
   }


### PR DESCRIPTION
Fix issue where add-asset-html-webpack-plugin could not be used multiple times to add multiple assets due to callback not being passed htmlPluginData as mentioned in the plugin docs [here](https://github.com/ampedandwired/html-webpack-plugin#events)