### PR TITLE
Add hash option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ Type: `string`, mandatory
 
 The absolute path of the file you want to add to the compilation, and resulting HTML file.
 
+#### `hash`
+Type: `boolean`, default: `false`
+
+If `true`, will append a unique hash of the file to the filename. This is useful for cache busting.
+
 #### `includeSourcemap`
 Type: `boolean`, default: `false`
 


### PR DESCRIPTION
I added hash option into AddAssetHtmlPlugin options. I think it's useful for cache busting.

## Example uses
Add `hash: true`.

```js
    new AddAssetHtmlPlugin({
      filename: require.resolve('./build/vendor.dll.js'),
      hash: true
    })
```

The generated HTML will be as follows.  The hash of `vendor.dll.js` is appended to the filename as query string.

```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="UTF-8">
    <title>My App</title>
  </head>
  <body>
  <script type="text/javascript" src="/js/vendor.dll.js?2916b8357bca6cf03b6f"></script><script type="text/javascript" src="/js/app.js?1c1192c642351cab268d"></script></body>
</html>
```