### PR TITLE
Add publicPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ Type: `boolean`, default: `false`
 
 If `true`, will add `filename + '.map'` to the compilation as well.
 
+#### `publicPath`
+Type: `string`
+
+If set, will be used as the public path of the script or link tag.
+
 #### `typeOfAsset`
 Type: `string`, default: `js`
 


### PR DESCRIPTION
Currently, the public path of the generated script or link tag depends on `output.publicPath` in `webpack.config.js`. I added `publicPath` option into AddAssetHtmlPlugin options to overwrite the path.

## Example use case

### `webpack.config.js`
```js:
module.exports = {
  entry: ['babel-polyfill', './src/script/index.tsx'],
  output: {
    path: path.join(__dirname, '../build'),
    publicPath: '',
    filename: 'assets/app.js'
  },
  plugins: [
    new HtmlWebpackPlugin({
      filename: 'index.html'
    }),
    new AddAssetHtmlPlugin({
      filename: require.resolve('./build/assets/vendor.js'),
      publicPath: 'assets'
    })
  ],
  ...
```

### The generated HTML

```html

<!doctype html>
<html>
  <head>
    <meta charset="utf-8">
    <title>My App</title>
  </head>
  <body>
    <div id="app"></div>

  <script type="text/javascript" src="assets/vendor.js?d7a424bd84a886d21d82"></script><script type="text/javascript" src="assets/app.js?02910af8479e3f4271e6"></script></body>
</html>

```