### PR TITLE
Add outputPath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ Type: `boolean`, default: `true`
 
 If `true`, will add `filepath + '.map'` to the compilation as well.
 
+#### `outputPath`
+Type: `string`
+
+If set, will be used as the output directory of the file.
+
 #### `publicPath`
 Type: `string`
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -5,6 +5,7 @@ interface PluginOptions {
   typeOfAsset?: string;
   includeSourcemap?: boolean;
   hash?: boolean;
+  outputPath?: string;
   publicPath?: string;
 }
 

--- a/test.js
+++ b/test.js
@@ -161,3 +161,28 @@ test('should add to css if `typeOfAsset` is css', async t => {
   t.true(callback.calledOnce);
   t.true(callback.calledWithExactly(null, pluginData));
 });
+
+test('should replace compilation assets key if `outputPath` is set', async t => {
+  const callback = sinon.stub();
+  const source = { source: () => 'test' };
+  const addFileToAssetsMock = (filename, compilation) => {
+    const name = path.basename(filename);
+    compilation.assets[name] = source; // eslint-disable-line no-param-reassign
+    return Promise.resolve(name);
+  };
+  const compilation = {
+    options: { output: {} },
+    assets: {},
+  };
+  const pluginData = { assets: { js: [], css: [] }, plugin: { addFileToAssets: addFileToAssetsMock } };
+
+  await addAllAssetsToCompilation([{ filepath: 'my-file.js', outputPath: 'assets' }], compilation, pluginData, callback);
+
+  t.deepEqual(pluginData.assets.css, []);
+  t.deepEqual(pluginData.assets.js, ['my-file.js']);
+
+  t.is(compilation.assets['my-file.js'], undefined);
+  t.deepEqual(compilation.assets['assets/my-file.js'], source);
+  t.is(compilation.assets['my-file.js.map'], undefined);
+  t.deepEqual(compilation.assets['assets/my-file.js.map'], source);
+});


### PR DESCRIPTION
Currently, the asset file is wrtten to webpack `output.path` directory always. To write the file into sub directory,   I added `outputPath` option into AddAssetHtmlPlugin options. 

## Example

### `webpack.config.js`
```js:
module.exports = {
  entry: ['babel-polyfill', './src/script/index.jsx'],
  output: {
    path: path.join(__dirname, './build'),
    publicPath: '',
    filename: 'app.js'
  },
  plugins: [
    new HtmlWebpackPlugin({
      filename: 'index.html'
    }),
    new AddAssetHtmlPlugin({
      filename: require.resolve('./build/assets/vendor.js'),
      publicPath: 'assets',
      outputPath: 'assets',
      includeSourcemap: true
    })
  ],
  ...
```

### The generated files

```
build
├─app.js
├─assets
│  ├─vendor.js
│  └─vendor.js.map
└─index.html
```

### The generated HTML

```html

<!doctype html>
<html>
  <head>
    <meta charset="utf-8">
    <title>My App</title>
  </head>
  <body>
    <div id="app"></div>

  <script type="text/javascript" src="assets/vendor.js?d7a424bd84a886d21d82"></script><script type="text/javascript" src="app.js?02910af8479e3f4271e6"></script></body>
</html>

```