### PR TITLE
Add outputName option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,13 @@ Type: `string`
 
 If set, will be used as the output directory of the file.
 
+#### `outputName`
+
+Type: `string`
+
+If set, will be used as the name of the file instead of filepath. Template string accepts `[name]` and `[contentHash]`
+place holders, e.g. `[name].[contentHash].js`.
+
 #### `publicPath`
 
 Type: `string`

--- a/src/addAllAssetsToCompilation.js
+++ b/src/addAllAssetsToCompilation.js
@@ -92,7 +92,7 @@ async function addFileToAssets(
     const addedMapFilename = await htmlPluginData.plugin.addFileToAssets(
       `${filepath}.map`,
       compilation,
-      `${outputName}.map`,
+      outputName != null ? `${outputName}.map` : undefined,
     );
     resolveOutput(compilation, addedMapFilename, outputPath);
   }

--- a/src/addAllAssetsToCompilation.js
+++ b/src/addAllAssetsToCompilation.js
@@ -44,6 +44,7 @@ async function addFileToAssets(
     publicPath,
     outputPath,
     files = [],
+    outputName,
   },
 ) {
   if (!filepath) {
@@ -67,6 +68,7 @@ async function addFileToAssets(
   const addedFilename = await htmlPluginData.plugin.addFileToAssets(
     filepath,
     compilation,
+    outputName,
   );
 
   let suffix = '';
@@ -90,6 +92,7 @@ async function addFileToAssets(
     const addedMapFilename = await htmlPluginData.plugin.addFileToAssets(
       `${filepath}.map`,
       compilation,
+      `${outputName}.map`,
     );
     resolveOutput(compilation, addedMapFilename, outputPath);
   }

--- a/test.js
+++ b/test.js
@@ -142,10 +142,41 @@ test('should add sourcemap to compilation', async () => {
   expect(addFileToAssetsStub.mock.calls[0]).toEqual([
     'my-file.js',
     compilation,
+    undefined,
   ]);
   expect(addFileToAssetsStub.mock.calls[1]).toEqual([
     'my-file.js.map',
     compilation,
+    undefined,
+  ]);
+});
+
+test('passes outputName option to addFileToAssetsStub', async () => {
+  const callback = jest.fn();
+  const addFileToAssetsStub = jest.fn();
+  const compilation = { options: { output: {} } };
+  const pluginData = {
+    assets: { js: [], css: [] },
+    plugin: { addFileToAssets: addFileToAssetsStub },
+  };
+  addFileToAssetsStub.mockReturnValue(Promise.resolve('my-file.js'));
+
+  await addAllAssetsToCompilation(
+    [{ filepath: 'my-file.js', outputName: '[name].[contentHash].js' }],
+    compilation,
+    pluginData,
+    callback,
+  );
+
+  expect(addFileToAssetsStub.mock.calls[0]).toEqual([
+    'my-file.js',
+    compilation,
+    '[name].[contentHash].js',
+  ]);
+  expect(addFileToAssetsStub.mock.calls[1]).toEqual([
+    'my-file.js.map',
+    compilation,
+    '[name].[contentHash].js.map',
   ]);
 });
 
@@ -172,7 +203,11 @@ test('should skip adding sourcemap to compilation if set to false', async () => 
   expect(callback).toHaveBeenCalledWith(null, pluginData);
 
   expect(addFileToAssetsStub).toHaveBeenCalledTimes(1);
-  expect(addFileToAssetsStub).toHaveBeenCalledWith('my-file.js', compilation);
+  expect(addFileToAssetsStub).toHaveBeenCalledWith(
+    'my-file.js',
+    compilation,
+    undefined,
+  );
 });
 
 test('should include hash of file content if option is set', async () => {


### PR DESCRIPTION
Depends on this PR in html-webpack-plugin: https://github.com/jantimon/html-webpack-plugin/pull/958

Allows for using a different output name to the source file, and including a content hash in the file name. 

Not all CDNs and proxies cache bust on changed query parameters. Allowing the contentHash and name placeholders brings more inline with webpack options.