### PR TITLE
fix: add support for html-webpack-plugin@4

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "eslint": "^5.6.0",
     "eslint-config-simenb-base": "^15.0.0",
     "eslint_d": "^7.1.0",
-    "html-webpack-plugin": "^3.0.4",
+    "html-webpack-plugin": "^4.0.0-0",
     "husky": "^0.14.3",
     "jest": "^23.6.0",
     "jest-watch-typeahead": "^0.2.0",
@@ -65,7 +65,7 @@
     "webpack-cli": "^3.1.0"
   },
   "peerDependencies": {
-    "html-webpack-plugin": "^3.0.4"
+    "html-webpack-plugin": "^3.0.4 || ^4.0.0-0"
   },
   "engines": {
     "node": ">=6"

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+import HtmlWebpackPlugin from 'html-webpack-plugin';
 import addAllAssetsToCompilation from './addAllAssetsToCompilation';
 
 export default class AddAssetHtmlPlugin {
@@ -8,10 +9,15 @@ export default class AddAssetHtmlPlugin {
   /* istanbul ignore next: this would be integration tests */
   apply(compiler) {
     compiler.hooks.compilation.tap('AddAssetHtmlPlugin', compilation => {
-      compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration.tapPromise(
-        'AddAssetHtmlPlugin',
-        htmlPluginData =>
-          addAllAssetsToCompilation(this.assets, compilation, htmlPluginData),
+      let hook;
+      if (HtmlWebpackPlugin.version === 4) {
+        hook = HtmlWebpackPlugin.getHooks(compilation).beforeAssetTagGeneration;
+      } else {
+        hook = compilation.hooks.htmlWebpackPluginBeforeHtmlGeneration;
+      }
+
+      hook.tapPromise('AddAssetHtmlPlugin', htmlPluginData =>
+        addAllAssetsToCompilation(this.assets, compilation, htmlPluginData),
       );
     });
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -551,6 +551,10 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@types/tapable@1.0.2":
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.2.tgz#e13182e1b69871a422d7863e11a4a6f5b814a4bd"
+
 "@webassemblyjs/ast@1.7.6":
   version "1.7.6"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.7.6.tgz#3ef8c45b3e5e943a153a05281317474fef63e21e"
@@ -2877,16 +2881,16 @@ html-minifier@^3.2.3:
     relateurl "0.2.x"
     uglify-js "3.4.x"
 
-html-webpack-plugin@^3.0.4:
-  version "3.2.0"
-  resolved "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz#b01abbd723acaaa7b37b6af4492ebda03d9dd37b"
+html-webpack-plugin@^4.0.0-0:
+  version "4.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/html-webpack-plugin/-/html-webpack-plugin-4.0.0-alpha.2.tgz#7745967e389a57a098e26963f328ebe4c19b598d"
   dependencies:
+    "@types/tapable" "1.0.2"
     html-minifier "^3.2.3"
-    loader-utils "^0.2.16"
-    lodash "^4.17.3"
+    loader-utils "^1.1.0"
+    lodash "^4.17.10"
     pretty-error "^2.0.2"
     tapable "^1.0.0"
-    toposort "^1.0.0"
     util.promisify "1.0.0"
 
 htmlparser2@~3.3.0:
@@ -3994,15 +3998,6 @@ loader-runner@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.3.0.tgz#f482aea82d543e07921700d5a46ef26fdac6b8a2"
 
-loader-utils@^0.2.16:
-  version "0.2.17"
-  resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-0.2.17.tgz#f86e6374d43205a6e6c60e9196f17c0299bfb348"
-  dependencies:
-    big.js "^3.1.3"
-    emojis-list "^2.0.0"
-    json5 "^0.5.0"
-    object-assign "^4.0.1"
-
 loader-utils@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.1.0.tgz#c98aef488bcceda2ffb5e2de646d6a754429f5cd"
@@ -4033,7 +4028,7 @@ lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
 
-lodash@^4.0.1, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5:
+lodash@^4.0.1, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -5880,10 +5875,6 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     extend-shallow "^3.0.2"
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
-
-toposort@^1.0.0:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/toposort/-/toposort-1.0.7.tgz#2e68442d9f64ec720b8cc89e6443ac6caa950029"
 
 tough-cookie@>=2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.4.3:
   version "2.4.3"


### PR DESCRIPTION
Fixes #132 

@jantimon thoughts on this? Seems to work fine (run `yarn example && open example/dist/index.html` to see a working example with dll and source map).

---

I have to admit it's more than 2 years since I did anything with Webpack so I haven't really followed along. So any pointers would be appreciated 🙂 