### PR TITLE
fix: fix "compilation.emitAsset" with more than 1 HtmlWebpackPlugins

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,9 @@ function addFileToAssetsWebpack5(filename, compilation) {
     .then(rawSource => {
       const basename = path.basename(resolvedFilename);
       compilation.fileDependencies.add(resolvedFilename);
-      compilation.emitAsset(basename, rawSource);
+      if (!compilation.getAsset(basename)) {
+        compilation.emitAsset(basename, rawSource);
+      }
       return basename;
     });
 }


### PR DESCRIPTION
fix: fix "compilation.emitAsset" with more than 1 HtmlWebpackPlugins. before emitAsset needs to check if it exists.